### PR TITLE
Decode dictionarys before lists.

### DIFF
--- a/Tests/PythonCodableTests/PythonCodableTests+Swift.swift
+++ b/Tests/PythonCodableTests/PythonCodableTests+Swift.swift
@@ -16,7 +16,7 @@ extension PythonCodableTests {
             struct SubSubStruct: Codable, Equatable {
                 let string: String
             }
-            
+
             let bool: Bool
             let string: String?
             let double: Double?
@@ -25,7 +25,7 @@ extension PythonCodableTests {
             let intArray: Array<Int>?
             let stringArrayArray: Array<Array<String?>>?
             let subSubStruct: SubSubStruct?
-            
+
             init(
                 bool: Bool,
                 string: String? = nil,
@@ -45,12 +45,12 @@ extension PythonCodableTests {
                 self.subSubStruct = subSubStruct
             }
         }
-        
+
         let int: Int
         let string: String?
         let bool: Bool?
         let subStruct: SubStruct?
-        
+
         init(
             int: Int,
             string: String? = nil,
@@ -60,6 +60,18 @@ extension PythonCodableTests {
             self.string = string
             self.bool = bool
             self.subStruct = subStruct
+        }
+    }
+
+    struct Struct2: Codable, Equatable {
+        let arrayOfStructs: [Struct]?
+        let arrayOfDicts: [[String: String]]?
+
+        init(
+            arrayOfStructs: [Struct]? = nil,
+            arrayOfDicts: [[String: String]]? = nil) {
+            self.arrayOfStructs = arrayOfStructs
+            self.arrayOfDicts = arrayOfDicts
         }
     }
 }

--- a/Tests/PythonCodableTests/Resources/PythonCodableTests.py
+++ b/Tests/PythonCodableTests/Resources/PythonCodableTests.py
@@ -14,7 +14,6 @@ class Struct:
             def __init__(self, string: str):
                 self.string = string
 
-
         def __init__(
             self,
             bool: bool,
@@ -33,7 +32,7 @@ class Struct:
             self.intArray = intArray
             self.stringArrayArray = stringArrayArray
             self.subSubStruct = subSubStruct
-            
+
     def __init__(
         self,
         int: int,
@@ -44,3 +43,11 @@ class Struct:
         self.string = string
         self.bool = bool
         self.subStruct = subStruct
+
+class Struct2:
+    def __init__(
+        self,
+        arrayOfStructs: List[Struct] = None,
+        arrayOfDicts: List[Dict[str, str]] = None):
+        self.arrayOfStructs = arrayOfStructs
+        self.arrayOfDicts = arrayOfDicts


### PR DESCRIPTION
This fixes a bug in decoding lists of dictionaries.  

The current logic checks if the current object `isPythonListOrListConvertible` before checking `isPythonDictionaryOrDictionaryConvertible`. The problem with this is `dict` is `ListConvertible` by the definition in the code, in that it implements `__iter__`. So the current code decodes the `dict` via `Python.list()` which returns a list of the `dict`'s keys.  This breaks when decoding a type like `[[String: String]]`, but also breaks when decoding a nested struct that just has a dict as a member.

This change implements the simplest fix, which is to try to decode dictionaries first, since lists are not `DictionaryConvertible`.  

This change includes simple tests to verify.  Without the fix:
```
Test Case '-[PythonCodableTests.PythonDecoderTests testArrayOfDictionaries]' started.
/Users/jeffdav/src/PythonCodable/.build/checkouts/MoreCodable/Sources/InternalFunction.swift:19: error: 
-[PythonCodableTests.PythonDecoderTests testArrayOfDictionaries] : failed: caught error: 
"typeMismatch(Swift.Dictionary<Swift.String, Any>, Swift.DecodingError.Context(codingPath:
 [CodingKeys(stringValue: "arrayOfDicts", intValue: nil), AnyCodingKey(stringValue: "Index 0", intValue: 0)], 
debugDescription: "Expected to decode Dictionary<String, Any> but found Optional<Any> instead.", underlyingError: nil))"
Test Case '-[PythonCodableTests.PythonDecoderTests testArrayOfDictionaries]' failed (0.057 seconds).
```

With the fix:
```
Test Case '-[PythonCodableTests.PythonDecoderTests testArrayOfDictionaries]' started.
Test Case '-[PythonCodableTests.PythonDecoderTests testArrayOfDictionaries]' passed (0.033 seconds).
```
